### PR TITLE
tag as 2.0.0 due to b/c breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-socialengine",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "ESLint Configs by SocialEngine used in our JavaScript Projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Originally, we wanted to use `minor` for B/C breaks in rules, but thats not how `semVer` does it, so biting the bullet and tagging recent changes as `2.0.0` instead of `1.1.0`
