### PR TITLE
Disallow spaces inside parentheses

### DIFF
--- a/rules/stylistic.js
+++ b/rules/stylistic.js
@@ -28,6 +28,8 @@ module.exports = {
     'new-cap': [2, { properties: false }],
     // no spaces in brackets
     'array-bracket-spacing': [2, 'never'],
+    // no spaces inside of parentheses
+    'space-in-parens': [2, 'never'],
     'block-spacing': [2, 'always'],
     'brace-style': 2,
     'eol-last': 2,


### PR DESCRIPTION
### What is the problem / feature ?

Currently spaces are being allowed inside parentheses, and no error is returned.
### How did it get fixed / implemented ?
- Added the [space-in-parens](http://eslint.org/docs/rules/space-in-parens) rule: `'space-in-parens': [2, "never"]`
### How can someone test / see it ?

1) Add a space in parentheses like this: `print( this is wrong)`. You’ll get an error.
2) Remove space in parentheses like this: `print(this is fine)`. You’ll not get an error.
