### PR TITLE
Disallow multi spaces

### DIFF
--- a/rules/stylistic.js
+++ b/rules/stylistic.js
@@ -30,6 +30,8 @@ module.exports = {
     'array-bracket-spacing': [2, 'never'],
     // no spaces inside of parentheses
     'space-in-parens': [2, 'never'],
+    // no multi spaces
+    'no-multi-spaces': 2,
     'block-spacing': [2, 'always'],
     'brace-style': 2,
     'eol-last': 2,


### PR DESCRIPTION
### What is the problem / feature ?

Currently multi spaces are being allowed and no error is returned.
### How did it get fixed / implemented ?
- Added the [no-multi-spaces](http://eslint.org/docs/rules/no-multi-spaces) rule: 'no-multi-spaces': 2,`
### How can someone test / see it ?

1) Add a multi spaces like this: `a = b +  c`. You’ll get an error.
2) Remove multi spaces like this: `a = b + c`. You’ll not get an error.
