### PR TITLE
Add rule for spaces require around infix operators

### DIFF
--- a/rules/stylistic.js
+++ b/rules/stylistic.js
@@ -28,6 +28,8 @@ module.exports = {
     'new-cap': [2, { properties: false }],
     // no spaces in brackets
     'array-bracket-spacing': [2, 'never'],
+    // spaces require around infix operators
+    'space-infix-ops': 2,
     // no spaces inside of parentheses
     'space-in-parens': [2, 'never'],
     // no multi spaces


### PR DESCRIPTION
### What is the problem / feature ?

Currently space is not  require around infix operators, and no error is returned.
### How did it get fixed / implemented ?
- Added the [space-infix-ops](http://eslint.org/docs/rules/space-infix-ops) rule: `'space-infix-ops': 2`
### How can someone test / see it ?

1) Remove a space around infix operators like this: `const str=This is error`. You’ll get an error.
2) Add space around infix operators like this: `const str = this is fine`. You’ll not get an error.
